### PR TITLE
Removed publishing info from build.sbt.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,15 +31,6 @@ version := versionRoot + "-" + versionSuffix.getOrElse((versionRevision + 1) + "
 
 val artifactory = "https://artifactory.broadinstitute.org/artifactory/"
 
-credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
-
-publishTo := {
-  if (isSnapshot.value)
-    None // NOTE: Use publish-local when working on snapshots
-  else
-    Option("artifactory-releases-publish" at artifactory + "libs-release-local")
-}
-
 resolvers += "artifactory-releases" at artifactory + "libs-release"
 
 scalaVersion := "2.11.2"


### PR DESCRIPTION
Info may be specified via the command line:

``` bash
sbt \
  'set credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")' \
  'set publishTo := Option("artifactory-releases-publish" at "https://artifactory.broadinstitute.org/artifactory/libs-release-local")' \
  clean test publish
```

Or:

``` bash
sbt \
  'set credentials += Credentials("Artifactory", "artifactory.broadinstitute.org", "user", "pass")' \
  'set publishTo := Option("artifactory-releases-publish" at "https://artifactory.broadinstitute.org/artifactory/libs-release-local")' \
  clean test publish
```
